### PR TITLE
Update Repository URLs

### DIFF
--- a/reports/2022-09-06/report.bib
+++ b/reports/2022-09-06/report.bib
@@ -114,14 +114,14 @@ url = {https://github.com/doanha86/Tezos-Ocaml-API},
 author = {Julian Mundhahs},
 title = {Tezos-Ocaml-API},
 year = {2021},
-url = {https://github.com/Qup42/tezos-api},
+url = {https://github.com/Tezos-Project-Uni-Freiburg/tezos-api},
 }
 
 @misc{tezos-api-devenv,
 author = {Julian Mundhahs},
 title = {Tezos-Ocaml-API},
 year = {2021},
-url = {https://github.com/Qup42/tezos-api-devenv},
+url = {https://github.com/Tezos-Project-Uni-Freiburg/tezos-api-devenv},
 }
 
 

--- a/reports/proposal/report.bib
+++ b/reports/proposal/report.bib
@@ -114,14 +114,14 @@ url = {https://github.com/doanha86/Tezos-Ocaml-API},
 author = {Julian Mundhahs},
 title = {Tezos-Ocaml-API},
 year = {2021},
-url = {https://github.com/Qup42/tezos-api},
+url = {https://github.com/Tezos-Project-Uni-Freiburg/tezos-api},
 }
 
 @misc{tezos-api-devenv,
 author = {Julian Mundhahs},
 title = {Tezos-Ocaml-API},
 year = {2021},
-url = {https://github.com/Qup42/tezos-api-devenv},
+url = {https://github.com/Tezos-Project-Uni-Freiburg/tezos-api-devenv},
 }
 
 


### PR DESCRIPTION
Update the URLs of the Repository in the `.bib` files. The repositories were moved so the URLs changed.